### PR TITLE
Don't get notifications for followed accounts

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,6 @@ for user in users:
             print(status[1].screen_name + " is not following you.")
 
         if(status[0].following==False):
-            api.create_friendship(screen_name= status[1].screen_name, follow=False)
+            api.create_friendship(screen_name= status[1].screen_name, follow=config["appear_in_my_feed"])
             print("Following: " + status[1].screen_name)
 

--- a/app.py
+++ b/app.py
@@ -29,6 +29,6 @@ for user in users:
             print(status[1].screen_name + " is not following you.")
 
         if(status[0].following==False):
-            api.create_friendship(screen_name= status[1].screen_name, follow=True)
+            api.create_friendship(screen_name= status[1].screen_name, follow=False)
             print("Following: " + status[1].screen_name)
 


### PR DESCRIPTION
Currently, if you follow all captains, you end up taking notifications from 67 people - that's too much to be default IMO
